### PR TITLE
Handle security-scoped access before PDF conversion

### DIFF
--- a/DarkPDF/ContentView.swift
+++ b/DarkPDF/ContentView.swift
@@ -109,6 +109,10 @@ struct ContentView: View {
             var exportFilename = "inverted.pdf"
 
             for url in urls {
+                // Access security-scoped resources so files selected from outside the sandbox can be read
+                guard url.startAccessingSecurityScopedResource() else { continue }
+                defer { url.stopAccessingSecurityScopedResource() }
+
                 if let data = try? processor.convert(url: url) {
                     let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent(url.deletingPathExtension().lastPathComponent + "_inverted.pdf")
                     try? data.write(to: tempURL)


### PR DESCRIPTION
## Summary
- ensure PDFs from outside the sandbox can be processed by starting/stopping security-scoped resource access

## Testing
- `swiftc DarkPDF/*.swift` *(fails: no such module 'SwiftUI')*


------
https://chatgpt.com/codex/tasks/task_e_6892059d258083219a4782519525c5ec