### PR TITLE
Fix PDF background inversion

### DIFF
--- a/DarkPDF/PDFProcessor.swift
+++ b/DarkPDF/PDFProcessor.swift
@@ -23,6 +23,12 @@ final class PDFProcessor {
             var mediaBox = page.getBoxRect(.mediaBox)
             context.beginPage(mediaBox: &mediaBox)
 
+            // Fill the page background so transparent regions are inverted as well.
+            context.saveGState()
+            context.setFillColor(gray: 1, alpha: 1)
+            context.fill(mediaBox)
+            context.restoreGState()
+
             // Draw original page content to preserve vectors and text.
             context.drawPDFPage(page)
 


### PR DESCRIPTION
## Summary
- ensure PDF page backgrounds are filled before color inversion so transparent areas render dark

## Testing
- `swiftc -typecheck DarkPDF/PDFProcessor.swift` *(fails: no such module 'PDFKit')*

------
https://chatgpt.com/codex/tasks/task_e_68920f71aaec83219429b37ed7c6f5c6