### PR TITLE
feat: improve annotation removal

### DIFF
--- a/DarkPDF/PDFPreviewView.swift
+++ b/DarkPDF/PDFPreviewView.swift
@@ -9,9 +9,10 @@ import UIKit
 /// SwiftUI wrapper around PDFKit's PDFView to provide cross-platform preview.
 struct PDFPreviewView: View {
     let url: URL
+    let includeAnnotations: Bool
 
     var body: some View {
-        Representable(url: url)
+        Representable(url: url, includeAnnotations: includeAnnotations)
             .background(Color.black)
     }
 }
@@ -19,41 +20,67 @@ struct PDFPreviewView: View {
 #if os(macOS)
 struct Representable: NSViewRepresentable {
     let url: URL
+    let includeAnnotations: Bool
 
     func makeNSView(context: Context) -> PDFView {
         let view = PDFView()
         view.autoScales = true
         view.displayMode = .singlePageContinuous
         view.backgroundColor = .black
-        view.document = PDFDocument(url: url)
+        view.document = makeDocument()
         return view
     }
 
     func updateNSView(_ nsView: PDFView, context: Context) {
-        if nsView.document?.documentURL != url {
-            nsView.document = PDFDocument(url: url)
-        }
+        nsView.document = makeDocument()
         nsView.backgroundColor = .black
+    }
+
+    private func makeDocument() -> PDFDocument? {
+        guard let doc = PDFDocument(url: url) else { return nil }
+        if !includeAnnotations {
+            for index in 0..<doc.pageCount {
+                if let page = doc.page(at: index) {
+                    for annotation in page.annotations {
+                        page.removeAnnotation(annotation)
+                    }
+                }
+            }
+        }
+        return doc
     }
 }
 #else
 struct Representable: UIViewRepresentable {
     let url: URL
+    let includeAnnotations: Bool
 
     func makeUIView(context: Context) -> PDFView {
         let view = PDFView()
         view.autoScales = true
         view.displayMode = .singlePageContinuous
         view.backgroundColor = .black
-        view.document = PDFDocument(url: url)
+        view.document = makeDocument()
         return view
     }
 
     func updateUIView(_ uiView: PDFView, context: Context) {
-        if uiView.document?.documentURL != url {
-            uiView.document = PDFDocument(url: url)
-        }
+        uiView.document = makeDocument()
         uiView.backgroundColor = .black
+    }
+
+    private func makeDocument() -> PDFDocument? {
+        guard let doc = PDFDocument(url: url) else { return nil }
+        if !includeAnnotations {
+            for index in 0..<doc.pageCount {
+                if let page = doc.page(at: index) {
+                    for annotation in page.annotations {
+                        page.removeAnnotation(annotation)
+                    }
+                }
+            }
+        }
+        return doc
     }
 }
 #endif


### PR DESCRIPTION
## Summary
- keep track of original PDFs so switching annotation removal reprocesses files
- strip annotations from preview rendering across Apple platforms

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `swiftc DarkPDF/ContentView.swift DarkPDF/PDFPreviewView.swift DarkPDF/PDFProcessor.swift -typecheck` *(fails: no such module 'SwiftUI')*


------
https://chatgpt.com/codex/tasks/task_e_6892f90a0238832194923bc5f543016a