### PR TITLE
Add annotation color replacement feature

### DIFF
--- a/DarkPDF/ColorReplacementView.swift
+++ b/DarkPDF/ColorReplacementView.swift
@@ -1,0 +1,66 @@
+import SwiftUI
+
+#if os(macOS)
+import AppKit
+#else
+import UIKit
+#endif
+
+struct ColorReplacementView: View {
+    let colors: [Color]
+    var onReplace: (Color, Color) -> Void
+    @State private var selected: Color?
+    @State private var newColor: Color = .red
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        VStack {
+            List(colors, id: \.self) { color in
+                HStack {
+                    Circle()
+                        .fill(color)
+                        .frame(width: 24, height: 24)
+                    Text(hexString(for: color))
+                    Spacer()
+                    if let selected, selected.cgColor == color.cgColor {
+                        Image(systemName: "checkmark")
+                    }
+                }
+                .contentShape(Rectangle())
+                .onTapGesture { selected = color }
+            }
+
+            if selected != nil {
+                ColorPicker("New Color", selection: $newColor)
+                    .padding(.vertical)
+                Button("Replace") {
+                    if let original = selected {
+                        onReplace(original, newColor)
+                        dismiss()
+                    }
+                }
+            }
+
+            Button("Cancel") { dismiss() }
+                .padding(.top)
+        }
+        .padding()
+        .frame(minWidth: 320, minHeight: 400)
+    }
+
+    private func hexString(for color: Color) -> String {
+#if os(macOS)
+        let ns = NSColor(color).usingColorSpace(.deviceRGB)!
+        return String(format: "#%02X%02X%02X", Int(ns.redComponent * 255), Int(ns.greenComponent * 255), Int(ns.blueComponent * 255))
+#else
+        let ui = UIColor(color)
+        var r: CGFloat = 0, g: CGFloat = 0, b: CGFloat = 0, a: CGFloat = 0
+        ui.getRed(&r, green: &g, blue: &b, alpha: &a)
+        return String(format: "#%02X%02X%02X", Int(r * 255), Int(g * 255), Int(b * 255))
+#endif
+    }
+}
+
+#Preview {
+    ColorReplacementView(colors: [.red, .blue]) { _, _ in }
+}

--- a/DarkPDF/ColorReplacementView.swift
+++ b/DarkPDF/ColorReplacementView.swift
@@ -15,34 +15,40 @@ struct ColorReplacementView: View {
 
     var body: some View {
         VStack {
-            List(colors, id: \.self) { color in
-                HStack {
-                    Circle()
-                        .fill(color)
-                        .frame(width: 24, height: 24)
-                    Text(hexString(for: color))
-                    Spacer()
-                    if let selected, selected.cgColor == color.cgColor {
-                        Image(systemName: "checkmark")
+            if colors.isEmpty {
+                Text("No annotation colors detected")
+                    .foregroundColor(.secondary)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else {
+                List(colors, id: \.self) { color in
+                    HStack {
+                        Circle()
+                            .fill(color)
+                            .frame(width: 24, height: 24)
+                        Text(hexString(for: color))
+                        Spacer()
+                        if let selected, selected.cgColor == color.cgColor {
+                            Image(systemName: "checkmark")
+                        }
+                    }
+                    .contentShape(Rectangle())
+                    .onTapGesture { selected = color }
+                }
+
+                if selected != nil {
+                    ColorPicker("New Color", selection: $newColor)
+                        .padding(.vertical)
+                    Button("Replace") {
+                        if let original = selected {
+                            onReplace(original, newColor)
+                            dismiss()
+                        }
                     }
                 }
-                .contentShape(Rectangle())
-                .onTapGesture { selected = color }
-            }
 
-            if selected != nil {
-                ColorPicker("New Color", selection: $newColor)
-                    .padding(.vertical)
-                Button("Replace") {
-                    if let original = selected {
-                        onReplace(original, newColor)
-                        dismiss()
-                    }
-                }
+                Button("Cancel") { dismiss() }
+                    .padding(.top)
             }
-
-            Button("Cancel") { dismiss() }
-                .padding(.top)
         }
         .padding()
         .frame(minWidth: 320, minHeight: 400)

--- a/DarkPDF/PDFProcessor.swift
+++ b/DarkPDF/PDFProcessor.swift
@@ -45,7 +45,11 @@ final class PDFProcessor {
         for index in 0..<document.pageCount {
             guard let page = document.page(at: index) else { continue }
             for annotation in page.annotations {
+#if os(macOS)
+                let color = annotation.color
+#else
                 guard let color = annotation.color else { continue }
+#endif
                 let rgba = color.rgba
                 if !set.contains(rgba) {
                     set.insert(rgba)
@@ -70,7 +74,11 @@ final class PDFProcessor {
         for index in 0..<document.pageCount {
             guard let page = document.page(at: index) else { continue }
             for annotation in page.annotations {
+#if os(macOS)
+                let color = annotation.color
+#else
                 guard let color = annotation.color else { continue }
+#endif
                 if color.rgba == fromRGBA {
                     annotation.color = toColor
                 }

--- a/DarkPDF/PDFProcessor.swift
+++ b/DarkPDF/PDFProcessor.swift
@@ -50,12 +50,14 @@ final class PDFProcessor {
 #else
                 let primary = annotation.color
 #endif
-                let candidate = primary ?? annotation.border?.color ?? annotation.interiorColor
-                guard let color = candidate else { continue }
-                let rgba = color.rgba
-                if !set.contains(rgba) {
-                    set.insert(rgba)
-                    colors.append(color)
+                let interior = annotation.interiorColor
+                for candidate in [primary, interior] {
+                    guard let color = candidate else { continue }
+                    let rgba = color.rgba
+                    if !set.contains(rgba) {
+                        set.insert(rgba)
+                        colors.append(color)
+                    }
                 }
             }
         }
@@ -81,14 +83,10 @@ final class PDFProcessor {
 #else
                 let primary = annotation.color
 #endif
-                let borderColor = annotation.border?.color
                 let interiorColor = annotation.interiorColor
-                let matches = [primary, borderColor, interiorColor].contains { $0?.rgba == fromRGBA }
+                let matches = [primary, interiorColor].contains { $0?.rgba == fromRGBA }
                 if matches {
                     annotation.color = toColor
-                    if let border = annotation.border {
-                        border.color = toColor
-                    }
                     annotation.interiorColor = toColor
                 }
             }

--- a/DarkPDF/PDFProcessor.swift
+++ b/DarkPDF/PDFProcessor.swift
@@ -2,8 +2,86 @@ import Foundation
 import PDFKit
 import CoreGraphics
 
+#if os(macOS)
+import AppKit
+typealias PlatformColor = NSColor
+#else
+import UIKit
+typealias PlatformColor = UIColor
+#endif
+
+/// Simple RGBA container so colors can be compared across platforms.
+private struct RGBA: Hashable {
+    let r: CGFloat
+    let g: CGFloat
+    let b: CGFloat
+    let a: CGFloat
+}
+
+private extension PlatformColor {
+    /// Normalised RGBA components for comparison and hashing.
+    var rgba: RGBA {
+#if os(macOS)
+        let rgb = usingColorSpace(.deviceRGB) ?? self
+        return RGBA(r: rgb.redComponent, g: rgb.greenComponent, b: rgb.blueComponent, a: rgb.alphaComponent)
+#else
+        var r: CGFloat = 0, g: CGFloat = 0, b: CGFloat = 0, a: CGFloat = 0
+        getRed(&r, green: &g, blue: &b, alpha: &a)
+        return RGBA(r: r, g: g, b: b, a: a)
+#endif
+    }
+}
+
 /// Performs black and white inversion on PDF content while preserving vector data.
 final class PDFProcessor {
+    /// Detects unique annotation colors in the provided PDF.
+    /// - Parameter url: Location of the source PDF
+    /// - Returns: Array of distinct colors used by annotations
+    func annotationColors(url: URL) -> [PlatformColor] {
+        guard let document = PDFDocument(url: url) else { return [] }
+        var set = Set<RGBA>()
+        var colors: [PlatformColor] = []
+
+        for index in 0..<document.pageCount {
+            guard let page = document.page(at: index) else { continue }
+            for annotation in page.annotations {
+                guard let color = annotation.color else { continue }
+                let rgba = color.rgba
+                if !set.contains(rgba) {
+                    set.insert(rgba)
+                    colors.append(color)
+                }
+            }
+        }
+        return colors
+    }
+
+    /// Replaces all annotation colors matching `fromColor` with `toColor` and returns new PDF data.
+    /// - Parameters:
+    ///   - url: Location of the source PDF
+    ///   - fromColor: Color to search for
+    ///   - toColor: Replacement color
+    func replaceAnnotations(url: URL, fromColor: PlatformColor, toColor: PlatformColor) throws -> Data {
+        guard let document = PDFDocument(url: url) else {
+            throw NSError(domain: "PDFProcessor", code: -1, userInfo: [NSLocalizedDescriptionKey: "Unable to open PDF"])
+        }
+        let fromRGBA = fromColor.rgba
+
+        for index in 0..<document.pageCount {
+            guard let page = document.page(at: index) else { continue }
+            for annotation in page.annotations {
+                guard let color = annotation.color else { continue }
+                if color.rgba == fromRGBA {
+                    annotation.color = toColor
+                }
+            }
+        }
+
+        guard let data = document.dataRepresentation() else {
+            throw NSError(domain: "PDFProcessor", code: -3, userInfo: [NSLocalizedDescriptionKey: "Unable to serialize PDF"])
+        }
+        return data
+    }
     /// Converts the PDF at the given URL by inverting all colors and returns the resulting PDF data.
     /// - Parameters:
     ///   - url: location of the source PDF


### PR DESCRIPTION
## Summary
- detect unique annotation colors in PDFs and allow color replacement
- add UI for listing annotation colors and choosing replacement
- update preview after annotation color changes

## Testing
- `swiftc -typecheck DarkPDF/*.swift` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_6892fcff80b083218c469490b81d5e2f